### PR TITLE
remove duplicated max delay check

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
@@ -74,9 +74,6 @@ public class BucketState implements Serializable {
             Bandwidth bandwidth = bandwidths[i];
             long delay = calculateDelayNanosAfterWillBePossibleToConsume(i, bandwidth, tokensToConsume, currentTimeNanos);
             delayAfterWillBePossibleToConsume = Math.max(delayAfterWillBePossibleToConsume, delay);
-            if (delay > delayAfterWillBePossibleToConsume) {
-                delayAfterWillBePossibleToConsume = delay;
-            }
         }
         return delayAfterWillBePossibleToConsume;
     }


### PR DESCRIPTION
Are they duplicated? Already a `Math.max` before if check.