### PR TITLE
basic-usage.md: Remove duplicate Bucket object declaration in ThrottlingFilter#doFilter

### DIFF
--- a/doc-pages/basic-usage.md
+++ b/doc-pages/basic-usage.md
@@ -79,7 +79,7 @@ public class ThrottlingFilter implements javax.servlet.Filter {
         String appKey = SecurityUtils.getThirdPartyAppKey();
         Bucket bucket = (Bucket) session.getAttribute("throttler-" + appKey);
         if (bucket == null) {
-            Bucket bucket = createNewBucket();
+            bucket = createNewBucket();
             session.setAttribute("throttler-" + appKey, bucket);
         }
 


### PR DESCRIPTION
`Bucket` object is being declared twice in the same function.
Further info in commit message.