### PR TITLE
change Bandwidth's fields to public for runtime checking

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/Bandwidth.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/Bandwidth.java
@@ -59,11 +59,11 @@ public class Bandwidth implements Serializable {
 
     private static final long serialVersionUID = 101L;
 
-    final long capacity;
-    final long initialTokens;
-    final long refillPeriodNanos;
-    final long refillTokens;
-    final boolean refillIntervally;
+    private final long capacity;
+    private final long initialTokens;
+    private final long refillPeriodNanos;
+    private final long refillTokens;
+    private final boolean refillIntervally;
 
     private Bandwidth(long capacity, long refillPeriodNanos, long refillTokens, long initialTokens, boolean refillIntervally) {
         this.capacity = capacity;
@@ -131,4 +131,23 @@ public class Bandwidth implements Serializable {
         return sb.toString();
     }
 
+    public long getCapacity() {
+        return capacity;
+    }
+
+    public long getInitialTokens() {
+        return initialTokens;
+    }
+
+    public long getRefillPeriodNanos() {
+        return refillPeriodNanos;
+    }
+
+    public long getRefillTokens() {
+        return refillTokens;
+    }
+
+    public boolean isRefillIntervally() {
+        return refillIntervally;
+    }
 }

--- a/bucket4j-core/src/test/java/io/github/bucket4j/EqualsUtil.java
+++ b/bucket4j-core/src/test/java/io/github/bucket4j/EqualsUtil.java
@@ -33,19 +33,19 @@ public class EqualsUtil {
         for (int i = 0; i < config1.getBandwidths().length; i++) {
             Bandwidth bandwidth1 = config1.getBandwidths()[i];
             Bandwidth bandwidth2 = config2.getBandwidths()[i];
-            if (bandwidth1.capacity != bandwidth2.capacity) {
+            if (bandwidth1.getCapacity() != bandwidth2.getCapacity()) {
                 return false;
             }
-            if (bandwidth1.initialTokens != bandwidth2.initialTokens) {
+            if (bandwidth1.getInitialTokens() != bandwidth2.getInitialTokens()) {
                 return false;
             }
-            if (bandwidth1.refillPeriodNanos != bandwidth2.refillPeriodNanos) {
+            if (bandwidth1.getRefillPeriodNanos() != bandwidth2.getRefillPeriodNanos()) {
                 return false;
             }
-            if (bandwidth1.refillIntervally != bandwidth2.refillIntervally) {
+            if (bandwidth1.isRefillIntervally() != bandwidth2.isRefillIntervally()) {
                 return false;
             }
-            if (bandwidth1.refillTokens != bandwidth2.refillTokens) {
+            if (bandwidth1.getRefillTokens() != bandwidth2.getRefillTokens()) {
                 return false;
             }
         }


### PR DESCRIPTION
For "change configuration of bucket on the fly" feature we should have the way to check current bundwidth settings and current  application settings to decide call replaceConfiguration