### PR TITLE
Implement Hazelcast serializers

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/Bandwidth.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/Bandwidth.java
@@ -67,8 +67,8 @@ public class Bandwidth implements Serializable {
     final long timeOfFirstRefillMillis;
     final boolean useAdaptiveInitialTokens;
 
-    private Bandwidth(long capacity, long refillPeriodNanos, long refillTokens, long initialTokens, boolean refillIntervally,
-                      long timeOfFirstRefillMillis, boolean useAdaptiveInitialTokens) {
+    Bandwidth(long capacity, long refillPeriodNanos, long refillTokens, long initialTokens, boolean refillIntervally,
+              long timeOfFirstRefillMillis, boolean useAdaptiveInitialTokens) {
         this.capacity = capacity;
         this.initialTokens = initialTokens;
         this.refillPeriodNanos = refillPeriodNanos;

--- a/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BandwidthSerializer.java
+++ b/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BandwidthSerializer.java
@@ -1,0 +1,62 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.nio.serialization.TypedStreamDeserializer;
+
+import java.io.IOException;
+
+
+public class BandwidthSerializer implements StreamSerializer<Bandwidth>, TypedStreamDeserializer<Bandwidth> {
+
+    private final int typeId;
+
+    public BandwidthSerializer(int typeId) {
+        this.typeId = typeId;
+    }
+
+    @Override
+    public int getTypeId() {
+        return this.typeId;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void write(ObjectDataOutput out, Bandwidth bandwidth) throws IOException {
+        out.writeLong(bandwidth.getCapacity());
+        out.writeLong(bandwidth.getInitialTokens());
+        out.writeLong(bandwidth.getRefillPeriodNanos());
+        out.writeLong(bandwidth.getRefillTokens());
+        out.writeBoolean(bandwidth.refillIntervally);
+        out.writeLong(bandwidth.getTimeOfFirstRefillMillis());
+        out.writeBoolean(bandwidth.useAdaptiveInitialTokens);
+    }
+
+    @Override
+    public Bandwidth read(ObjectDataInput in) throws IOException {
+        return read0(in);
+    }
+
+    @Override
+    public Bandwidth read(ObjectDataInput in, Class aClass) throws IOException {
+        return read0(in);
+    }
+
+    private Bandwidth read0(ObjectDataInput in) throws IOException {
+        long capacity = in.readLong();
+        long initialTokens = in.readLong();
+        long refillPeriodNanos = in.readLong();
+        long refillTokens = in.readLong();
+        boolean refillIntervally = in.readBoolean();
+        long timeOfFirstRefillMillis = in.readLong();
+        boolean useAdaptiveInitialTokens = in.readBoolean();
+
+        return new Bandwidth(capacity, refillPeriodNanos, refillTokens, initialTokens, refillIntervally,
+                timeOfFirstRefillMillis, useAdaptiveInitialTokens);
+    }
+}

--- a/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BucketConfigurationSerializer.java
+++ b/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BucketConfigurationSerializer.java
@@ -1,0 +1,58 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.nio.serialization.TypedStreamDeserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BucketConfigurationSerializer implements StreamSerializer<BucketConfiguration>, TypedStreamDeserializer<BucketConfiguration> {
+
+    private final int typeId;
+
+    public BucketConfigurationSerializer(int typeId) {
+        this.typeId = typeId;
+    }
+
+    @Override
+    public int getTypeId() {
+        return typeId;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void write(ObjectDataOutput out, BucketConfiguration bucketConfiguration) throws IOException {
+        Bandwidth[] bandwidths = bucketConfiguration.getBandwidths();
+        out.writeInt(bandwidths.length);
+        for (Bandwidth bandwidth : bandwidths) {
+            out.writeObject(bandwidth);
+        }
+    }
+
+    @Override
+    public BucketConfiguration read(ObjectDataInput in) throws IOException {
+        return read0(in);
+    }
+
+    @Override
+    public BucketConfiguration read(ObjectDataInput in, Class aClass) throws IOException {
+        return read0(in);
+    }
+
+    private BucketConfiguration read0(ObjectDataInput in) throws IOException {
+        int bandwidthAmount = in.readInt();
+        List<Bandwidth> bandwidths = new ArrayList<>(bandwidthAmount);
+        for (int ii = 0; ii < bandwidthAmount; ii++) {
+            Bandwidth bandwidth = in.readObject(Bandwidth.class);
+            bandwidths.add(bandwidth);
+        }
+        return new BucketConfiguration(bandwidths);
+    }
+}

--- a/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BucketStateSerializer.java
+++ b/bucket4j-hazelcast/src/main/java/io/github/bucket4j/BucketStateSerializer.java
@@ -1,0 +1,47 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.nio.serialization.TypedStreamDeserializer;
+
+import java.io.IOException;
+
+public class BucketStateSerializer implements StreamSerializer<BucketState>, TypedStreamDeserializer<BucketState> {
+
+    private final int typeId;
+
+    public BucketStateSerializer(int typeId) {
+        this.typeId = typeId;
+    }
+
+    @Override
+    public int getTypeId() {
+        return this.typeId;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void write(ObjectDataOutput out, BucketState bucketState) throws IOException {
+        out.writeLongArray(bucketState.stateData);
+    }
+
+    @Override
+    public BucketState read(ObjectDataInput in) throws IOException {
+        return read0(in);
+    }
+
+    @Override
+    public BucketState read(ObjectDataInput in, Class aClass) throws IOException {
+        return read0(in);
+    }
+
+    private BucketState read0(ObjectDataInput in) throws IOException {
+        long[] stateData = in.readLongArray();
+        return new BucketState(stateData);
+    }
+}

--- a/bucket4j-hazelcast/src/main/java/io/github/bucket4j/CommandResultSerializer.java
+++ b/bucket4j-hazelcast/src/main/java/io/github/bucket4j/CommandResultSerializer.java
@@ -1,0 +1,55 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.nio.serialization.TypedStreamDeserializer;
+import io.github.bucket4j.grid.CommandResult;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+
+public class CommandResultSerializer<T extends Serializable> implements StreamSerializer<CommandResult<T>>, TypedStreamDeserializer<CommandResult<T>> {
+
+    private final int typeId;
+
+    public CommandResultSerializer(int typeId) {
+        this.typeId = typeId;
+    }
+
+    @Override
+    public int getTypeId() {
+        return this.typeId;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void write(ObjectDataOutput out, CommandResult<T> commandResult) throws IOException {
+        out.writeBoolean(commandResult.isBucketNotFound());
+        if (!commandResult.isBucketNotFound()) {
+            out.writeObject(commandResult.getData());
+        }
+    }
+
+    @Override
+    public CommandResult<T> read(ObjectDataInput in) throws IOException {
+        return read0(in);
+    }
+
+    @Override
+    public CommandResult<T> read(ObjectDataInput in, Class aClass) throws IOException {
+        return read0(in);
+    }
+
+    private CommandResult<T> read0(ObjectDataInput in) throws IOException {
+        boolean isBucketNotFound = in.readBoolean();
+        return isBucketNotFound
+                ? CommandResult.bucketNotFound()
+                : CommandResult.success(in.readObject());
+    }
+}

--- a/bucket4j-hazelcast/src/main/java/io/github/bucket4j/GridBucketStateSerializer.java
+++ b/bucket4j-hazelcast/src/main/java/io/github/bucket4j/GridBucketStateSerializer.java
@@ -1,0 +1,50 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.nio.serialization.TypedStreamDeserializer;
+import io.github.bucket4j.grid.GridBucketState;
+
+import java.io.IOException;
+
+public class GridBucketStateSerializer implements StreamSerializer<GridBucketState>, TypedStreamDeserializer<GridBucketState> {
+
+    private final int typeId;
+
+    public GridBucketStateSerializer(int typeId) {
+        this.typeId = typeId;
+    }
+
+    @Override
+    public int getTypeId() {
+        return this.typeId;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void write(ObjectDataOutput out, GridBucketState gridBucketState) throws IOException {
+        out.writeObject(gridBucketState.getConfiguration());
+        out.writeObject(gridBucketState.getState());
+    }
+
+    @Override
+    public GridBucketState read(ObjectDataInput in) throws IOException {
+        return read0(in);
+    }
+
+    @Override
+    public GridBucketState read(ObjectDataInput in, Class aClass) throws IOException {
+        return read0(in);
+    }
+
+    private GridBucketState read0(ObjectDataInput in) throws IOException {
+        BucketConfiguration bucketConfiguration = in.readObject(BucketConfiguration.class);
+        BucketState bucketState = in.readObject(BucketState.class);
+        return new GridBucketState(bucketConfiguration, bucketState);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BandwidthSerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BandwidthSerializerTest.java
@@ -1,0 +1,52 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+import static io.github.bucket4j.Bandwidth.classic;
+import static io.github.bucket4j.Bandwidth.simple;
+import static io.github.bucket4j.Refill.greedy;
+import static io.github.bucket4j.Refill.intervally;
+import static io.github.bucket4j.Refill.intervallyAligned;
+import static java.time.Duration.ofSeconds;
+
+public class BandwidthSerializerTest extends SerializerTest<Bandwidth> {
+
+    @Override
+    protected StreamSerializer<Bandwidth> getSerializerUnderTest() {
+        return this.bandwidthSerializer;
+    }
+
+    @Override
+    protected void runAssertions(Bandwidth original, Bandwidth deserialized) {
+        SerializationAssertions.assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void serializeSimpleBandwidth() throws IOException {
+        Bandwidth bandwidth = simple(10, ofSeconds(20));
+        testSerialization(bandwidth);
+    }
+
+    @Test
+    public void serializeClassicBandwidthWithGreedyRefill() throws IOException {
+        Bandwidth bandwidth = classic(20, greedy(100, Duration.ofSeconds(42)));
+        testSerialization(bandwidth);
+    }
+
+    @Test
+    public void serializeClassicBandwidthWithIntervallyRefill() throws IOException {
+        Bandwidth bandwidth = classic(30, intervally(200, Duration.ofSeconds(420)));
+        testSerialization(bandwidth);
+    }
+
+    @Test
+    public void serializeClassicBandwidthWithIntervallyAlignedRefill() throws IOException {
+        Bandwidth bandwidth = classic(40, intervallyAligned(300, Duration.ofSeconds(4200), Instant.now(), true));
+        testSerialization(bandwidth);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BucketConfigurationSerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BucketConfigurationSerializerTest.java
@@ -1,0 +1,51 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static io.github.bucket4j.Bandwidth.classic;
+import static io.github.bucket4j.Bandwidth.simple;
+import static io.github.bucket4j.Refill.greedy;
+import static io.github.bucket4j.Refill.intervallyAligned;
+import static java.time.Duration.ofDays;
+import static java.time.Duration.ofHours;
+import static java.time.Duration.ofSeconds;
+
+public class BucketConfigurationSerializerTest extends SerializerTest<BucketConfiguration> {
+
+    @Override
+    protected StreamSerializer<BucketConfiguration> getSerializerUnderTest() {
+        return this.bucketConfigurationSerializer;
+    }
+
+    @Override
+    protected void runAssertions(BucketConfiguration original, BucketConfiguration deserialized) {
+        SerializationAssertions.assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void serializeBucketConfiguration_withSingleBandwidth() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+
+        testSerialization(bucketConfiguration);
+    }
+
+    @Test
+    public void serializeBucketConfiguration_withMultipleBandwidths() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42)),
+                classic(20, greedy(300, ofHours(2))),
+                classic(400, intervallyAligned(1000, ofDays(2), Instant.now().plusNanos(1), true))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+
+        testSerialization(bucketConfiguration);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BucketStateSerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/BucketStateSerializerTest.java
@@ -1,0 +1,68 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static io.github.bucket4j.Bandwidth.classic;
+import static io.github.bucket4j.Bandwidth.simple;
+import static io.github.bucket4j.Refill.greedy;
+import static io.github.bucket4j.Refill.intervallyAligned;
+import static java.time.Duration.ofDays;
+import static java.time.Duration.ofHours;
+import static java.time.Duration.ofSeconds;
+
+public class BucketStateSerializerTest extends SerializerTest<BucketState> {
+
+    @Override
+    protected StreamSerializer<BucketState> getSerializerUnderTest() {
+        return this.bucketStateSerializer;
+    }
+
+    @Override
+    protected void runAssertions(BucketState original, BucketState deserialized) {
+        SerializationAssertions.assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void serializeBucketState_withSingleBandwidth_withoutState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+
+        testSerialization(bucketState);
+    }
+
+    @Test
+    public void serializeBucketState_withSingleBandwidth_withState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+
+        bucketState.addTokens(bandwidths, 300);
+
+        testSerialization(bucketState);
+    }
+
+    @Test
+    public void serializeBucketState_withMultipleBandwidths_withState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42)),
+                classic(20, greedy(300, ofHours(2))),
+                classic(400, intervallyAligned(1000, ofDays(2), Instant.now(), false))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+
+        bucketState.addTokens(bandwidths, 42);
+
+        testSerialization(bucketState);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/CommandResultSerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/CommandResultSerializerTest.java
@@ -1,0 +1,43 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.serialization.StreamSerializer;
+import io.github.bucket4j.grid.CommandResult;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommandResultSerializerTest<T extends Serializable> extends SerializerTest<CommandResult<T>> {
+
+    @Override
+    protected StreamSerializer<CommandResult<T>> getSerializerUnderTest() {
+        return this.commandResultSerializer;
+    }
+
+    @Override
+    protected void runAssertions(CommandResult original, CommandResult deserialized) {
+        assertEquals(original.isBucketNotFound(), deserialized.isBucketNotFound());
+        assertEquals(original.getData(), deserialized.getData());
+    }
+
+    @Test
+    public void serializeCommandResult_withoutPayload() throws IOException {
+        testSerialization(CommandResult.bucketNotFound());
+    }
+
+    @Test
+    public void serializeCommandResult_withIntegerPayload() throws IOException {
+        CommandResult<T> commandResult = (CommandResult<T>) CommandResult.success(42L);
+
+        testSerialization(commandResult);
+    }
+
+    @Test
+    public void serializeCommandResult_withStringPayload() throws IOException {
+        CommandResult<T> commandResult = (CommandResult<T>) CommandResult.success("foo");
+
+        testSerialization(commandResult);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/GridBucketStateSerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/GridBucketStateSerializerTest.java
@@ -1,0 +1,90 @@
+package io.github.bucket4j;
+
+import com.hazelcast.nio.serialization.StreamSerializer;
+import io.github.bucket4j.grid.GridBucketState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static io.github.bucket4j.Bandwidth.classic;
+import static io.github.bucket4j.Bandwidth.simple;
+import static io.github.bucket4j.Refill.greedy;
+import static io.github.bucket4j.Refill.intervallyAligned;
+import static java.time.Duration.ofDays;
+import static java.time.Duration.ofHours;
+import static java.time.Duration.ofSeconds;
+
+public class GridBucketStateSerializerTest extends SerializerTest<GridBucketState> {
+
+    @Override
+    protected StreamSerializer<GridBucketState> getSerializerUnderTest() {
+        return this.gridBucketStateSerializer;
+    }
+
+    @Override
+    protected void runAssertions(GridBucketState original, GridBucketState deserialized) {
+        BucketConfiguration originalConfiguration = original.getConfiguration();
+        BucketConfiguration deserializedConfiguration = deserialized.getConfiguration();
+        SerializationAssertions.assertEquals(originalConfiguration, deserializedConfiguration);
+
+        BucketState originalState = original.getState();
+        BucketState deserializedState = deserialized.getState();
+        SerializationAssertions.assertEquals(originalState, deserializedState);
+    }
+
+    @Test
+    public void test() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+        GridBucketState gridBucketState = new GridBucketState(bucketConfiguration, bucketState);
+
+        testSerialization(gridBucketState);
+    }
+
+    @Test
+    public void serializeGridBucketState_withSingleBandwidth_withoutState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+        GridBucketState gridBucketState = new GridBucketState(bucketConfiguration, bucketState);
+
+        testSerialization(gridBucketState);
+    }
+
+    @Test
+    public void serializeGridBucketState_withSingleBandwidth_withState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+
+        bucketState.addTokens(bandwidths, 300);
+        GridBucketState gridBucketState = new GridBucketState(bucketConfiguration, bucketState);
+
+        testSerialization(gridBucketState);
+    }
+
+    @Test
+    public void serializeGridBucketState_withMultipleBandwidths_withState() throws IOException {
+        Bandwidth[] bandwidths = new Bandwidth[]{
+                simple(10, ofSeconds(42)),
+                classic(20, greedy(300, ofHours(2))),
+                classic(400, intervallyAligned(1000, ofDays(2), Instant.now(), false))
+        };
+        BucketConfiguration bucketConfiguration = new BucketConfiguration(Arrays.asList(bandwidths));
+        BucketState bucketState = new BucketState(bucketConfiguration, System.nanoTime());
+
+        bucketState.addTokens(bandwidths, 42);
+        GridBucketState gridBucketState = new GridBucketState(bucketConfiguration, bucketState);
+
+        testSerialization(gridBucketState);
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/SerializationAssertions.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/SerializationAssertions.java
@@ -1,0 +1,37 @@
+package io.github.bucket4j;
+
+import org.junit.Assert;
+
+import static org.junit.Assert.assertArrayEquals;
+
+class SerializationAssertions {
+
+    static void assertEquals(Bandwidth original, Bandwidth deserialized) {
+        Assert.assertEquals(original.getCapacity(), deserialized.getCapacity());
+        Assert.assertEquals(original.getInitialTokens(), deserialized.getInitialTokens());
+        Assert.assertEquals(original.getRefillPeriodNanos(), deserialized.getRefillPeriodNanos());
+        Assert.assertEquals(original.getRefillTokens(), deserialized.getRefillTokens());
+        Assert.assertEquals(original.refillIntervally, deserialized.refillIntervally);
+        Assert.assertEquals(original.getTimeOfFirstRefillMillis(), deserialized.getTimeOfFirstRefillMillis());
+        Assert.assertEquals(original.useAdaptiveInitialTokens, deserialized.useAdaptiveInitialTokens);
+    }
+
+    static void assertEquals(BucketConfiguration original, BucketConfiguration deserialized) {
+        Bandwidth[] originalBandwidths = original.getBandwidths();
+        Bandwidth[] deserializedBandwidths = deserialized.getBandwidths();
+        Assert.assertEquals(originalBandwidths.length, deserializedBandwidths.length);
+
+        for (int ii = 0; ii < deserializedBandwidths.length; ii++) {
+            Bandwidth originalBandwidth = originalBandwidths[ii];
+            Bandwidth deserializedBandwidth = deserializedBandwidths[ii];
+            assertEquals(originalBandwidth, deserializedBandwidth);
+        }
+    }
+
+    static void assertEquals(BucketState original, BucketState deserialized) {
+        assertArrayEquals(original.stateData, deserialized.stateData);
+    }
+
+    private SerializationAssertions() {
+    }
+}

--- a/bucket4j-hazelcast/src/test/java/io/github/bucket4j/SerializerTest.java
+++ b/bucket4j-hazelcast/src/test/java/io/github/bucket4j/SerializerTest.java
@@ -1,0 +1,65 @@
+package io.github.bucket4j;
+
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import io.github.bucket4j.grid.CommandResult;
+import io.github.bucket4j.grid.GridBucketState;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public abstract class SerializerTest<T> {
+
+    BandwidthSerializer bandwidthSerializer = new BandwidthSerializer(1);
+    BucketConfigurationSerializer bucketConfigurationSerializer = new BucketConfigurationSerializer(2);
+    BucketStateSerializer bucketStateSerializer = new BucketStateSerializer(3);
+    CommandResultSerializer commandResultSerializer = new CommandResultSerializer(4);
+    GridBucketStateSerializer gridBucketStateSerializer = new GridBucketStateSerializer(5);
+
+    private InternalSerializationService serializationService;
+
+    @Before
+    public void setup() {
+        SerializationConfig serializationConfig = new SerializationConfig()
+                .addSerializerConfig(new SerializerConfig()
+                        .setImplementation(bandwidthSerializer)
+                        .setTypeClass(Bandwidth.class))
+                .addSerializerConfig(new SerializerConfig()
+                        .setImplementation(bucketConfigurationSerializer)
+                        .setTypeClass(BucketConfiguration.class))
+                .addSerializerConfig(new SerializerConfig()
+                        .setImplementation(bucketStateSerializer)
+                        .setTypeClass(BucketState.class))
+                .addSerializerConfig(new SerializerConfig()
+                        .setImplementation(commandResultSerializer)
+                        .setTypeClass(CommandResult.class))
+                .addSerializerConfig(new SerializerConfig()
+                        .setImplementation(gridBucketStateSerializer)
+                        .setTypeClass(GridBucketState.class));
+
+        this.serializationService = new DefaultSerializationServiceBuilder()
+                .setConfig(serializationConfig)
+                .build();
+    }
+
+    protected abstract StreamSerializer<T> getSerializerUnderTest();
+
+    protected abstract void runAssertions(T original, T deserialized);
+
+    void testSerialization(T original) throws IOException {
+        StreamSerializer<T> serializer = getSerializerUnderTest();
+
+        BufferObjectDataOutput out = serializationService.createObjectDataOutput();
+        serializer.write(out, original);
+
+        BufferObjectDataInput in = serializationService.createObjectDataInput(out.toByteArray());
+        T deserialized = serializer.read(in);
+
+        runAssertions(original, deserialized);
+    }
+}


### PR DESCRIPTION
Ahoy,

this PR provides a (fairly naive) implementation of [Hazelcast serialization](https://docs.hazelcast.org/docs/3.0/manual/html/ch03s03.html). By default, Java serialization is used, which can be rather slow and should be avoided, which is the main motivation of this PR.

Alternatives & why they were not chosen:

- Making the bucket4j classes implement Hazelcasts DataSerializable seemed suboptimal to me:
  - bucket4j-core should not depend on Hazelcast
  - don't want to have mandatory default constructors and mutable fields

- Not contributing the serializers:
Providing these Serializers from outside was not possible without reflection to get/construct `BucketState.stateData`,  `Bandwidth.refillIntervally` and `Bandwidth.useAdaptiveInitialTokens`. That is also the reason that the Serializers are in the `io.github.bucket4j` package and the change to the `Bandwidth` constructor, because that way we can access those fields.


Maybe a better solution to access these fields could be suggested / implemented by bucket4j so that its users can have the full freedom of implementing their own serializers, but that call needs to be made by the maintainer of bucket4j. I would be happy with any solution :)