### PR TITLE
GridBucketState_toString

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/grid/GridBucketState.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/grid/GridBucketState.java
@@ -108,5 +108,14 @@ public class GridBucketState implements Serializable {
     public BucketState getState() {
         return state;
     }
+    
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("GridBucketState{");
+        sb.append("configuration=").append(configuration);
+        sb.append(", state=").append(state);
+        sb.append('}');
+        return sb.toString();
+    }
 
 }


### PR DESCRIPTION
Hi @vladimir-bukhtoyarov ,

Many thanks for this great library. 

We are planning to use this in distributed mode on Hazelcast 3 and we are happy with initial experimentation.

We think that it would be great to have a detailed toString representation of GridBucketState. Hazelcast offers management center tool which enables to monitor map entries. 

It would be great to have a detailed representation of GridBucketState for monitoring purposes.

Regards