### PR TITLE
Depend on OSS Coherence CE instead of the commercially licensed version

### DIFF
--- a/bucket4j-coherence/pom.xml
+++ b/bucket4j-coherence/pom.xml
@@ -33,12 +33,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.oracle</groupId>
+            <groupId>com.oracle.coherence.ce</groupId>
             <artifactId>coherence</artifactId>
-            <version>12.2.1.0</version>
-            <scope>system</scope>
-            <!-- Point directly to jar from repository, because oracle does not provide maven distribution of coherence  -->
-            <systemPath>${project.basedir}/lib/cl.jar</systemPath>
+            <version>21.06</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>


### PR DESCRIPTION
You should depend on the open source [Coherence Community Edition](https://github.com/oracle/coherence), which is available in Maven Central instead of the commercial version. Nothing in Bucket4J requires any of the commercial Coherence features. Having the Coherence jar committed in your repo probably violates Oracle's license too.