### PR TITLE
ehcache should be test scope

### DIFF
--- a/bucket4j-jcache/pom.xml
+++ b/bucket4j-jcache/pom.xml
@@ -69,6 +69,7 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>${ehcache.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
ehcache got added as compile scope and now comes transitively into my project that is using the spring boot starter. This breaks an existing application that was using caffeine as the jcache provider