### PR TITLE
Fix Export-Package OSGi metadata in parent POM

### DIFF
--- a/bucket4j-parent/pom.xml
+++ b/bucket4j-parent/pom.xml
@@ -125,7 +125,7 @@
     Automatic-Module-Name: io.github.bucket4j.${modular-name}
 
     # Export your own packages; import everything else
-    Export-Package: ${project.groupId}.*;version="${project.version}"
+    -exportcontents: io.github.bucket4j.*;version="${project.version}";-noimport:=true
     Import-Package: *
 
     # Nice-to-have OSGi metadata


### PR DESCRIPTION
This is a fix for the accidentally missing `Export-Package`s in https://github.com/bucket4j/bucket4j/pull/561
Sorry for that. 

This PR:

Replaces the variable-based package export with the explicit 'io.github.bucket4j.*' pattern in the OSGi Export-Package directive to ensure correct package export in generated metadata. (as suggested by @cmark in https://github.com/bucket4j/bucket4j/pull/561#issuecomment-3713974021)

Also replaces `Export-Package` with `-exportcontents` and adds `-noimport:=true` for `io.github.bucket4j.*` in the OSGi metadata. This change improves control over package exports and imports for OSGi environments. for example `-exportcontents` ensures that only packages of the current bundle are exported an not like `Export-Package` which considers the bundle classpath. `-noimport:=true` ensures that exported packages are not automatically imported (allowing [package substitution](https://bnd.bndtools.org/chapters/170-versioning.html#substitution) - a feature of OSGi which is rarely wanted for pure libraries which were not developed with OSGi in mind). In bnd 7.2.0 there is a new [`-nosubstitution`](https://bnd.bndtools.org/instructions/nosubstitution.html) instruction for this


## MANIFEST of io.github.bucket4j.core

```

bnd print -m  */target/bucket4j_jdk17-core-8.16.0*.jar

[MANIFEST]

Archiver-Version                        Plexus Archiver
Automatic-Module-Name                   io.github.bucket4j.core
Build-Jdk                               21.0.7
Built-By                                christoph
Bundle-Description                      Bucket4j core library
Bundle-Developers                       MaxBartkov;email="maxgalayoutop@gmail.com";name="Maxim Bartkov";organization="Jaja finance";organizationUrl="https://jaja.co.uk";roles="Java Technical Leader"
                                        vladimir-bukhtoyarov;email="jsecoder@mail.ru";name="Vladimir Bukhtoyarov";organization=Vkontakte;organizationUrl="https://vk.com/";roles="Software developer"
Bundle-DocURL                           http://github.com/bucket4j/bucket4j/bucket4j_jdk17-core
Bundle-License                          "The Apache Software License, Version 2.0";link="http://www.apache.org/licenses/LICENSE-2.0"
Bundle-ManifestVersion                  2
Bundle-Name                             bucket4j_jdk17-core
Bundle-SCM                              connection="scm:git:git@github.com:bucket4j/bucket4j/bucket4j_jdk17-core"
                                        developer-connection="scm:git:git@github.com:bucket4j/bucket4j.git/bucket4j_jdk17-core"
                                        tag=HEAD
                                        url="http://github.com/bucket4j/bucket4j/bucket4j_jdk17-core"
Bundle-SymbolicName                     com.bucket4j.core
Bundle-Vendor                           Vladimir Bukhtoyarov
Bundle-Version                          8.16.0
Created-By                              Apache Maven 3.8.5
Export-Package                          io.github.bucket4j.distributed.expiration;version="8.16.0";uses:="io.github.bucket4j.distributed,io.github.bucket4j.distributed.remote,io.github.bucket4j.distributed.serialization,io.github.bucket4j.util"
                                        io.github.bucket4j.distributed.jdbc;version="8.16.0";uses:="io.github.bucket4j.distributed,io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.remote,javax.sql"
                                        io.github.bucket4j.distributed.proxy.generic.compare_and_swap;version="8.16.0";uses:="io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.remote"
                                        io.github.bucket4j.distributed.proxy.generic.pessimistic_locking;version="8.16.0";uses:="io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.remote"
                                        io.github.bucket4j.distributed.proxy.generic.select_for_update;version="8.16.0";uses:="io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.remote"
                                        io.github.bucket4j.distributed.proxy.optimization.batch;version="8.16.0";uses:="io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.proxy.optimization,io.github.bucket4j.distributed.remote"
                                        io.github.bucket4j.distributed.proxy.optimization.delay;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.proxy.optimization"
                                        io.github.bucket4j.distributed.proxy.optimization.manual;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.proxy.optimization"
                                        io.github.bucket4j.distributed.proxy.optimization.predictive;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.proxy.optimization"
                                        io.github.bucket4j.distributed.proxy.optimization.skiponzero;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.proxy,io.github.bucket4j.distributed.proxy.optimization"
                                        io.github.bucket4j.distributed.proxy.optimization;version="8.16.0";uses:="io.github.bucket4j.distributed.proxy"
                                        io.github.bucket4j.distributed.proxy;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed,io.github.bucket4j.distributed.proxy.optimization,io.github.bucket4j.distributed.remote,io.github.bucket4j.distributed.versioning"
                                        io.github.bucket4j.distributed.remote.commands;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.remote,io.github.bucket4j.distributed.serialization,io.github.bucket4j.distributed.versioning,io.github.bucket4j.util"
                                        io.github.bucket4j.distributed.remote;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed,io.github.bucket4j.distributed.remote.commands,io.github.bucket4j.distributed.serialization,io.github.bucket4j.distributed.versioning,io.github.bucket4j.util"
                                        io.github.bucket4j.distributed.serialization;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.remote,io.github.bucket4j.distributed.versioning"
                                        io.github.bucket4j.distributed.versioning;version="8.16.0"
                                        io.github.bucket4j.distributed;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.remote,io.github.bucket4j.distributed.serialization,io.github.bucket4j.distributed.versioning"
                                        io.github.bucket4j.local;version="8.16.0";uses:="io.github.bucket4j,io.github.bucket4j.distributed.serialization,io.github.bucket4j.util"
                                        io.github.bucket4j.util.concurrent.batch;version="8.16.0"
                                        io.github.bucket4j.util;version="8.16.0"
                                        io.github.bucket4j;version="8.16.0";uses:="io.github.bucket4j.distributed.serialization,io.github.bucket4j.distributed.versioning,io.github.bucket4j.local,io.github.bucket4j.util"
Implementation-Title                    bucket4j_jdk17-core
Implementation-Vendor-Id                com.bucket4j
Implementation-Version                  8.16.0
Import-Package                          java.io
                                        java.lang
                                        java.lang.annotation
                                        java.lang.invoke
                                        java.nio.charset
                                        java.sql
                                        java.text
                                        java.time
                                        java.util
                                        java.util.concurrent
                                        java.util.concurrent.atomic
                                        java.util.concurrent.locks
                                        java.util.function
                                        javax.sql
Manifest-Version                        1.0
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
Specification-Title                     bucket4j_jdk17-core
Specification-Version                   8.16.0
VERSION-FOR-REVAPI-COMPARISION          4.10.0

```

## All Manifests

```
bnd print -m  */target/*.jar > allmanifests.txt
```

[allmanifests-bnd.txt](https://github.com/user-attachments/files/24450919/allmanifests-bnd.txt)


All packages to verify:

```
find . -type f -name '*.java' -exec grep -h '^package ' {} + | sed 's/^package //' | sort -u  > allpackages.txt
```

[allpackages.txt](https://github.com/user-attachments/files/24450602/allpackages.txt)
