### PR TITLE
fix typo in compatible table

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In addition to local in-memory buckets, the Bucket4j supports clustered usage sc
 
 ### Valkey back-ends
 | Back-end                   |  Async supported | Redis cluster supported |                                       Documentation link                                       |
+| :---                       | :---:            |:-----------------------:|:----------------------------------------------------------------------------------------------:|
 | ```Valkey/Glide```         |  Yes             |           Yes           | [bucket4j-valkey/Glide](https://bucket4j.github.io/8.16.0/toc.html#toc.html#bucket4j-glide) |
 
 


### PR DESCRIPTION
Fixed a typo in the compatible table within README.md.
