### PR TITLE
fix(docs): Bucket4j-Glide Anchor

### DIFF
--- a/asciidoc/src/main/docs/asciidoc/distributed/redis/glide.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/redis/glide.adoc
@@ -1,4 +1,4 @@
-[[bucket4j-lettuce, Bucket4j-Lettuce]]
+[[bucket4j-glide, Bucket4j-Glide]]
 ==== Valkey glide integration
 ===== Dependencies
 To use ``valkey-glide`` extension you need to add following dependency:


### PR DESCRIPTION
Fixing the anchor so that link from README will work