### PR TITLE
Fix typo in hazelcast doc

### DIFF
--- a/asciidoc/src/main/docs/asciidoc/distributed/jcache/hazelcast.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/jcache/hazelcast.adoc
@@ -58,7 +58,7 @@ private static final HazelcastProxyManager<K> proxyManager = Bucket4jHazelcast
     .build();
 ----
 How to choose eviction jitter properly? Zero means immediate eviction after refill,
-however it is better to avoid too small jitter, because recreation of bucket after expiration will require one network hope,
+however it is better to avoid too small jitter, because recreation of bucket after expiration will require one network hop,
 so it is better to configure at least of few seconds for jitter in order to avoid to frequent buckets recreation.
 
 ===== Configuring Custom Serialization for Bucket4j library classes


### PR DESCRIPTION
Replaces `network hope` with `network hop` in the docs (https://bucket4j.com/8.17.0/toc.html#configuring-flexible-per-entry-expiration).