### PR TITLE
Add Couchbase backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ In addition to local in-memory buckets, the Bucket4j supports clustered usage sc
 | ```Apache Ignite```        |  Yes             |              No               |           n/a           |         Yes         |     [bucket4j-ignite](https://bucket4j.github.io/8.17.0/toc.html#bucket4j-ignite)     |
 | ```Inifinispan```          |  Yes             |              Yes              |           Yes           |         No          | [bucket4j-infinispan](https://bucket4j.github.io/8.17.0/toc.html#bucket4j-infinispan) |
 | ```Oracle Coherence```     |  Yes             |              Yes              |           Yes           |         No          |  [bucket4j-coherence](https://bucket4j.github.io/8.17.0/toc.html#bucket4j-coherence)  |
+| ```Couchbase```            |  Yes             |              Yes              |           Yes           |         No          |   [bucket4j-couchbase](https://bucket4j.github.io/8.17.0/toc.html#bucket4j-couchbase)  |
 
 ### Redis back-ends
 | Back-end                   |  Async supported | Redis cluster supported |                                       Documentation link                                       |

--- a/asciidoc/src/main/docs/asciidoc/distributed/couchbase/couchbase.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/couchbase/couchbase.adoc
@@ -1,0 +1,63 @@
+[[bucket4j-couchbase, Bucket4j-Couchbase]]
+=== Bucket4j-Couchbase
+Bucket4j provides integration with Couchbase through the synchronous Couchbase Java SDK KV API.
+
+This integration uses compare-and-swap based on Couchbase document CAS.
+Bucket state is stored as binary document content.
+Expiration is delegated to Couchbase document TTL.
+
+===== Dependencies
+To use ``bucket4j_jdk17-couchbase`` you need to add the following dependency:
+[source, xml, subs=attributes+]
+----
+<dependency>
+    <groupId>com.bucket4j</groupId>
+    <artifactId>bucket4j_jdk17-couchbase</artifactId>
+    <version>{revnumber}</version>
+</dependency>
+<dependency>
+    <groupId>com.couchbase.client</groupId>
+    <artifactId>java-client</artifactId>
+    <version>3.9.1</version>
+</dependency>
+----
+
+===== Example of Bucket instantiation via CouchbaseCompareAndSwapBasedProxyManager
+[source, java]
+----
+Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
+Bucket couchbaseBucket = cluster.bucket("bucket4j");
+couchbaseBucket.waitUntilReady(ofSeconds(10));
+Collection collection = couchbaseBucket.defaultCollection();
+
+CouchbaseCompareAndSwapBasedProxyManager<String> proxyManager =
+    Bucket4jCouchbase.compareAndSwapBasedBuilder(collection)
+        .expirationAfterWrite(ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(ofSeconds(10)))
+        .build();
+
+BucketConfiguration configuration = BucketConfiguration.builder()
+    .addLimit(limit -> limit.capacity(1_000).refillGreedy(1_000, ofMinutes(1)))
+    .build();
+
+Bucket bucketProxy = proxyManager.getProxy("user-123", () -> configuration);
+----
+
+===== Custom key mapping
+By default, the integration uses String keys.
+You can specify custom key types using a Mapper:
+[source, java]
+----
+CouchbaseCompareAndSwapBasedProxyManager<Long> proxyManager =
+    Bucket4jCouchbase.compareAndSwapBasedBuilder(collection, Mapper.LONG)
+        .build();
+
+Bucket bucket = proxyManager.getProxy(123L, () -> configuration);
+----
+
+Custom key mappers must produce valid Couchbase document ids because `Mapper.toString(key)` is used as the document key.
+
+===== Important notes
+* Async API is not supported
+* Expired buckets rely on Couchbase automatic document expiration
+* Expiration values below one second are rounded up to one second
+* Bucket state is stored as binary data in each document

--- a/asciidoc/src/main/docs/asciidoc/distributed/distributed-index.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/distributed-index.adoc
@@ -11,3 +11,5 @@ include::redis/redis.adoc[]
 include::jdbc/jdbc-integrations.adoc[]
 
 include::mongodb/mongodb-integrations.adoc[]
+
+include::couchbase/couchbase.adoc[]

--- a/bucket4j-couchbase/pom.xml
+++ b/bucket4j-couchbase/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>bucket4j_jdk17-parent</artifactId>
+        <groupId>com.bucket4j</groupId>
+        <version>8.17.0</version>
+        <relativePath>../bucket4j-parent</relativePath>
+    </parent>
+
+    <artifactId>bucket4j_jdk17-couchbase</artifactId>
+    <name>bucket4j_jdk17-couchbase</name>
+
+    <properties>
+        <modular-name>couchbase</modular-name>
+        <couchbase.java-client.version>3.9.1</couchbase.java-client.version>
+        <testcontainers.couchbase.version>2.0.2</testcontainers.couchbase.version>
+        <slf4j.version>2.0.9</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>java-client</artifactId>
+            <version>${couchbase.java-client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.couchbase.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-couchbase</artifactId>
+            <version>${testcontainers.couchbase.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotations.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/bucket4j-couchbase/src/main/java/io/github/bucket4j/couchbase/Bucket4jCouchbase.java
+++ b/bucket4j-couchbase/src/main/java/io/github/bucket4j/couchbase/Bucket4jCouchbase.java
@@ -1,0 +1,144 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Bucket4j
+ * %%
+ * Copyright (C) 2015 - 2025 Vladimir Bukhtoyarov
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package io.github.bucket4j.couchbase;
+
+import com.couchbase.client.java.AsyncCollection;
+import com.couchbase.client.java.Collection;
+import io.github.bucket4j.distributed.proxy.AbstractProxyManagerBuilder;
+import io.github.bucket4j.distributed.serialization.Mapper;
+
+import java.util.Objects;
+
+import static io.github.bucket4j.distributed.serialization.Mapper.STRING;
+
+/**
+ * Entry point for Couchbase integration that uses the Couchbase Java SDK.
+ */
+public class Bucket4jCouchbase {
+
+    /**
+     * Returns the builder for {@link CouchbaseCompareAndSwapBasedProxyManager}
+     *
+     * @param collection Couchbase collection that holds buckets.
+     *
+     * @return new instance of {@link CouchbaseCompareAndSwapBasedProxyManagerBuilder}
+     */
+    public static CouchbaseCompareAndSwapBasedProxyManagerBuilder<String> compareAndSwapBasedBuilder(Collection collection) {
+        return new CouchbaseCompareAndSwapBasedProxyManagerBuilder<>(collection, STRING);
+    }
+
+    /**
+     * Returns the builder for {@link CouchbaseCompareAndSwapBasedProxyManager}
+     *
+     * <p>
+     * Use this overload when the application already works with the asynchronous Couchbase API and
+     * does not want to keep a reference to the blocking {@link Collection} facade.
+     *
+     * @param collection Couchbase async collection that holds buckets.
+     *
+     * @return new instance of {@link CouchbaseCompareAndSwapBasedProxyManagerBuilder}
+     */
+    public static CouchbaseCompareAndSwapBasedProxyManagerBuilder<String> compareAndSwapBasedBuilder(AsyncCollection collection) {
+        return new CouchbaseCompareAndSwapBasedProxyManagerBuilder<>(collection, STRING);
+    }
+
+    /**
+     * Returns the builder for {@link CouchbaseCompareAndSwapBasedProxyManager}
+     *
+     * @param collection Couchbase collection that holds buckets.
+     * @param keyMapper object responsible for mapping keys from {@link K} to document ids.
+     * @param <K> type of primary key
+     *
+     * @return new instance of {@link CouchbaseCompareAndSwapBasedProxyManagerBuilder}
+     */
+    public static <K> CouchbaseCompareAndSwapBasedProxyManagerBuilder<K> compareAndSwapBasedBuilder(Collection collection, Mapper<K> keyMapper) {
+        return new CouchbaseCompareAndSwapBasedProxyManagerBuilder<>(collection, keyMapper);
+    }
+
+    /**
+     * Returns the builder for {@link CouchbaseCompareAndSwapBasedProxyManager}
+     *
+     * <p>
+     * Use this overload when the application already works with the asynchronous Couchbase API and
+     * does not want to keep a reference to the blocking {@link Collection} facade.
+     *
+     * @param collection Couchbase async collection that holds buckets.
+     * @param keyMapper object responsible for mapping keys from {@link K} to document ids.
+     * @param <K> type of primary key
+     *
+     * @return new instance of {@link CouchbaseCompareAndSwapBasedProxyManagerBuilder}
+     */
+    public static <K> CouchbaseCompareAndSwapBasedProxyManagerBuilder<K> compareAndSwapBasedBuilder(AsyncCollection collection, Mapper<K> keyMapper) {
+        return new CouchbaseCompareAndSwapBasedProxyManagerBuilder<>(collection, keyMapper);
+    }
+
+    public static class CouchbaseCompareAndSwapBasedProxyManagerBuilder<K> extends AbstractProxyManagerBuilder<K, CouchbaseCompareAndSwapBasedProxyManager<K>, CouchbaseCompareAndSwapBasedProxyManagerBuilder<K>> {
+
+        private final Collection collection;
+        private final AsyncCollection asyncCollection;
+        private Mapper<K> keyMapper;
+
+        public CouchbaseCompareAndSwapBasedProxyManagerBuilder(Collection collection, Mapper<K> keyMapper) {
+            this.collection = Objects.requireNonNull(collection);
+            this.asyncCollection = collection.async();
+            this.keyMapper = Objects.requireNonNull(keyMapper);
+        }
+
+        public CouchbaseCompareAndSwapBasedProxyManagerBuilder(AsyncCollection collection, Mapper<K> keyMapper) {
+            this.collection = null;
+            this.asyncCollection = Objects.requireNonNull(collection);
+            this.keyMapper = Objects.requireNonNull(keyMapper);
+        }
+
+        public Collection getCollection() {
+            return collection;
+        }
+
+        public AsyncCollection getAsyncCollection() {
+            return asyncCollection;
+        }
+
+        /**
+         * Specifies the type of key.
+         *
+         * @param keyMapper object responsible for converting primary keys to Couchbase document ids.
+         *
+         * @return this builder instance
+         */
+        public <K2> CouchbaseCompareAndSwapBasedProxyManagerBuilder<K2> keyMapper(Mapper<K2> keyMapper) {
+            this.keyMapper = (Mapper) Objects.requireNonNull(keyMapper);
+            return (CouchbaseCompareAndSwapBasedProxyManagerBuilder<K2>) this;
+        }
+
+        public Mapper<K> getKeyMapper() {
+            return keyMapper;
+        }
+
+        @Override
+        public boolean isExpireAfterWriteSupported() {
+            return true;
+        }
+
+        @Override
+        public CouchbaseCompareAndSwapBasedProxyManager<K> build() {
+            return new CouchbaseCompareAndSwapBasedProxyManager<>(this);
+        }
+    }
+}

--- a/bucket4j-couchbase/src/main/java/io/github/bucket4j/couchbase/CouchbaseCompareAndSwapBasedProxyManager.java
+++ b/bucket4j-couchbase/src/main/java/io/github/bucket4j/couchbase/CouchbaseCompareAndSwapBasedProxyManager.java
@@ -1,0 +1,297 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Bucket4j
+ * %%
+ * Copyright (C) 2015 - 2025 Vladimir Bukhtoyarov
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package io.github.bucket4j.couchbase;
+
+import com.couchbase.client.core.error.CasMismatchException;
+import com.couchbase.client.core.error.DocumentExistsException;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.java.AsyncCollection;
+import com.couchbase.client.java.AsyncUtils;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.codec.RawBinaryTranscoder;
+import com.couchbase.client.java.kv.GetResult;
+import com.couchbase.client.java.kv.GetOptions;
+import com.couchbase.client.java.kv.InsertOptions;
+import com.couchbase.client.java.kv.MutationResult;
+import com.couchbase.client.java.kv.RemoveOptions;
+import com.couchbase.client.java.kv.ReplaceOptions;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.expiration.NoneExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.generic.compare_and_swap.AbstractCompareAndSwapBasedProxyManager;
+import io.github.bucket4j.distributed.proxy.generic.compare_and_swap.AsyncCompareAndSwapOperation;
+import io.github.bucket4j.distributed.proxy.generic.compare_and_swap.CompareAndSwapOperation;
+import io.github.bucket4j.distributed.remote.RemoteBucketState;
+import io.github.bucket4j.distributed.serialization.Mapper;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static com.couchbase.client.java.kv.GetOptions.getOptions;
+import static com.couchbase.client.java.kv.InsertOptions.insertOptions;
+import static com.couchbase.client.java.kv.RemoveOptions.removeOptions;
+import static com.couchbase.client.java.kv.ReplaceOptions.replaceOptions;
+
+/**
+ * Compare-and-swap-based proxy manager for Couchbase that uses KV operations from the Couchbase Java SDK.
+ * Both blocking and asynchronous execution modes share the same CAS and TTL semantics.
+ *
+ * @param <K> type of primary key
+ */
+public class CouchbaseCompareAndSwapBasedProxyManager<K> extends AbstractCompareAndSwapBasedProxyManager<K> {
+
+    private static final RawBinaryTranscoder RAW_BINARY_TRANSCODER = RawBinaryTranscoder.INSTANCE;
+
+    private final Collection collection;
+    private final AsyncCollection asyncCollection;
+    private final Mapper<K> keyMapper;
+    private final ExpirationAfterWriteStrategy expirationStrategy;
+
+    protected CouchbaseCompareAndSwapBasedProxyManager(Bucket4jCouchbase.CouchbaseCompareAndSwapBasedProxyManagerBuilder<K> builder) {
+        super(builder.getClientSideConfig());
+        this.collection = builder.getCollection();
+        this.asyncCollection = builder.getAsyncCollection();
+        this.keyMapper = builder.getKeyMapper();
+        this.expirationStrategy = builder.getClientSideConfig()
+            .getExpirationAfterWriteStrategy()
+            .orElseGet(ExpirationAfterWriteStrategy::none);
+    }
+
+    @Override
+    protected CompareAndSwapOperation beginCompareAndSwapOperation(K key) {
+        return new CompareAndSwapOperation() {
+            private final String documentId = keyMapper.toString(key);
+            private long currentCas;
+
+            @Override
+            public Optional<byte[]> getStateData(Optional<Long> timeoutNanos) {
+                try {
+                    GetResult persistedState = executeGet(documentId, timeoutNanos);
+                    currentCas = persistedState.cas();
+                    return Optional.of(persistedState.contentAsBytes());
+                } catch (DocumentNotFoundException e) {
+                    currentCas = 0L;
+                    return Optional.empty();
+                }
+            }
+
+            @Override
+            public boolean compareAndSwap(byte[] originalData, byte[] newData, RemoteBucketState newState, Optional<Long> timeoutNanos) {
+                if (originalData == null) {
+                    try {
+                        executeInsert(documentId, newData, newState, timeoutNanos);
+                        return true;
+                    } catch (DocumentExistsException e) {
+                        return false;
+                    }
+                }
+
+                try {
+                    MutationResult result = executeReplace(documentId, newData, newState, currentCas, timeoutNanos);
+                    currentCas = result.cas();
+                    return true;
+                } catch (DocumentNotFoundException | CasMismatchException e) {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected AsyncCompareAndSwapOperation beginAsyncCompareAndSwapOperation(K key) {
+        return new AsyncCompareAndSwapOperation() {
+            private final String documentId = keyMapper.toString(key);
+            private volatile long currentCas;
+
+            @Override
+            public CompletableFuture<Optional<byte[]>> getStateData(Optional<Long> timeoutNanos) {
+                return asyncCollection.get(documentId, buildGetOptions(timeoutNanos))
+                    .thenApply(persistedState -> {
+                        currentCas = persistedState.cas();
+                        return Optional.of(persistedState.contentAsBytes());
+                    })
+                    .handle((state, error) -> {
+                        if (error == null) {
+                            return state;
+                        }
+                        Throwable cause = unwrap(error);
+                        if (cause instanceof DocumentNotFoundException) {
+                            currentCas = 0L;
+                            return Optional.<byte[]>empty();
+                        }
+                        throw rethrow(cause);
+                    });
+            }
+
+            @Override
+            public CompletableFuture<Boolean> compareAndSwap(byte[] originalData, byte[] newData, RemoteBucketState newState, Optional<Long> timeoutNanos) {
+                if (originalData == null) {
+                    return asyncCollection.insert(documentId, newData, buildInsertOptions(newState, timeoutNanos))
+                        .thenApply(result -> true)
+                        .handle((inserted, error) -> {
+                            if (error == null) {
+                                return inserted;
+                            }
+                            Throwable cause = unwrap(error);
+                            if (cause instanceof DocumentExistsException) {
+                                return false;
+                            }
+                            throw rethrow(cause);
+                        });
+                }
+
+                return asyncCollection.replace(documentId, newData, buildReplaceOptions(newState, currentCas, timeoutNanos))
+                    .thenApply(result -> {
+                        currentCas = result.cas();
+                        return true;
+                    })
+                    .handle((replaced, error) -> {
+                        if (error == null) {
+                            return replaced;
+                        }
+                        Throwable cause = unwrap(error);
+                        if (cause instanceof DocumentNotFoundException || cause instanceof CasMismatchException) {
+                            return false;
+                        }
+                        throw rethrow(cause);
+                    });
+            }
+        };
+    }
+
+    @Override
+    protected CompletableFuture<Void> removeAsync(K key) {
+        String documentId = keyMapper.toString(key);
+        return asyncCollection.remove(documentId, buildRemoveOptions(Optional.empty()))
+            .thenApply(result -> null)
+            .handle((ignored, error) -> {
+                if (error == null) {
+                    return null;
+                }
+                Throwable cause = unwrap(error);
+                if (cause instanceof DocumentNotFoundException) {
+                    return null;
+                }
+                throw rethrow(cause);
+            });
+    }
+
+    @Override
+    public void removeProxy(K key) {
+        try {
+            executeRemove(keyMapper.toString(key), Optional.empty());
+        } catch (DocumentNotFoundException e) {
+            // ignore
+        }
+    }
+
+    @Override
+    public boolean isAsyncModeSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isExpireAfterWriteSupported() {
+        return true;
+    }
+
+    private GetResult executeGet(String documentId, Optional<Long> timeoutNanos) {
+        if (collection != null) {
+            return collection.get(documentId, buildGetOptions(timeoutNanos));
+        }
+        return AsyncUtils.block(asyncCollection.get(documentId, buildGetOptions(timeoutNanos)));
+    }
+
+    private MutationResult executeInsert(String documentId, byte[] newData, RemoteBucketState newState, Optional<Long> timeoutNanos) {
+        if (collection != null) {
+            return collection.insert(documentId, newData, buildInsertOptions(newState, timeoutNanos));
+        }
+        return AsyncUtils.block(asyncCollection.insert(documentId, newData, buildInsertOptions(newState, timeoutNanos)));
+    }
+
+    private MutationResult executeReplace(String documentId, byte[] newData, RemoteBucketState newState, long cas, Optional<Long> timeoutNanos) {
+        if (collection != null) {
+            return collection.replace(documentId, newData, buildReplaceOptions(newState, cas, timeoutNanos));
+        }
+        return AsyncUtils.block(asyncCollection.replace(documentId, newData, buildReplaceOptions(newState, cas, timeoutNanos)));
+    }
+
+    private MutationResult executeRemove(String documentId, Optional<Long> timeoutNanos) {
+        if (collection != null) {
+            return collection.remove(documentId, buildRemoveOptions(timeoutNanos));
+        }
+        return AsyncUtils.block(asyncCollection.remove(documentId, buildRemoveOptions(timeoutNanos)));
+    }
+
+    private GetOptions buildGetOptions(Optional<Long> timeoutNanos) {
+        GetOptions options = getOptions().transcoder(RAW_BINARY_TRANSCODER);
+        timeoutNanos.map(Duration::ofNanos).ifPresent(options::timeout);
+        return options;
+    }
+
+    private InsertOptions buildInsertOptions(RemoteBucketState newState, Optional<Long> timeoutNanos) {
+        InsertOptions options = insertOptions().transcoder(RAW_BINARY_TRANSCODER);
+        timeoutNanos.map(Duration::ofNanos).ifPresent(options::timeout);
+        expiryFor(newState).ifPresent(options::expiry);
+        return options;
+    }
+
+    private ReplaceOptions buildReplaceOptions(RemoteBucketState newState, long cas, Optional<Long> timeoutNanos) {
+        ReplaceOptions options = replaceOptions()
+            .transcoder(RAW_BINARY_TRANSCODER)
+            .cas(cas);
+        timeoutNanos.map(Duration::ofNanos).ifPresent(options::timeout);
+        expiryFor(newState).ifPresent(options::expiry);
+        return options;
+    }
+
+    private RemoveOptions buildRemoveOptions(Optional<Long> timeoutNanos) {
+        RemoveOptions options = removeOptions();
+        timeoutNanos.map(Duration::ofNanos).ifPresent(options::timeout);
+        return options;
+    }
+
+    private Optional<Duration> expiryFor(RemoteBucketState newState) {
+        if (expirationStrategy.getClass() == NoneExpirationAfterWriteStrategy.class) {
+            return Optional.empty();
+        }
+
+        long ttlMillis = expirationStrategy.calculateTimeToLiveMillis(newState, currentTimeNanos());
+        if (ttlMillis < 1_000) {
+            return Optional.of(Duration.ofSeconds(1));
+        }
+        return Optional.of(Duration.ofMillis(ttlMillis));
+    }
+
+    private Throwable unwrap(Throwable error) {
+        if (error instanceof CompletionException completionException && completionException.getCause() != null) {
+            return completionException.getCause();
+        }
+        return error;
+    }
+
+    private RuntimeException rethrow(Throwable error) {
+        if (error instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return new CompletionException(error);
+    }
+}

--- a/bucket4j-couchbase/src/test/java/CouchbaseTest.java
+++ b/bucket4j-couchbase/src/test/java/CouchbaseTest.java
@@ -1,0 +1,75 @@
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+import io.github.bucket4j.couchbase.Bucket4jCouchbase;
+import io.github.bucket4j.distributed.serialization.Mapper;
+import io.github.bucket4j.tck.AbstractDistributedBucketTest;
+import io.github.bucket4j.tck.ProxyManagerSpec;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.couchbase.BucketDefinition;
+import org.testcontainers.couchbase.CouchbaseContainer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class CouchbaseTest extends AbstractDistributedBucketTest {
+
+    private static final String BUCKET_NAME = "bucket4j";
+
+    private static CouchbaseContainer couchbaseContainer;
+    private static Cluster cluster;
+
+    @BeforeAll
+    public static void setupCouchbase() {
+        couchbaseContainer = new CouchbaseContainer("couchbase/server:7.6.2")
+            .withBucket(new BucketDefinition(BUCKET_NAME).withPrimaryIndex(false));
+        couchbaseContainer.start();
+
+        cluster = Cluster.connect(
+            couchbaseContainer.getConnectionString(),
+            couchbaseContainer.getUsername(),
+            couchbaseContainer.getPassword()
+        );
+
+        Bucket bucket = cluster.bucket(BUCKET_NAME);
+        bucket.waitUntilReady(Duration.ofMinutes(2));
+        Collection collection = bucket.defaultCollection();
+        var asyncCollection = collection.async();
+
+        specs = List.of(
+            new ProxyManagerSpec<>(
+                "CouchbaseCompareAndSwapBasedProxyManager",
+                () -> UUID.randomUUID().toString(),
+                () -> Bucket4jCouchbase.compareAndSwapBasedBuilder(collection)
+            ).checkExpiration(),
+            new ProxyManagerSpec<>(
+                "CouchbaseCompareAndSwapBasedProxyManagerAsyncCollection",
+                () -> UUID.randomUUID().toString(),
+                () -> Bucket4jCouchbase.compareAndSwapBasedBuilder(asyncCollection)
+            ).checkExpiration(),
+            new ProxyManagerSpec<>(
+                "CouchbaseCompareAndSwapBasedProxyManagerWithLongKeys",
+                () -> ThreadLocalRandom.current().nextLong(),
+                () -> Bucket4jCouchbase.compareAndSwapBasedBuilder(collection, Mapper.LONG)
+            ).checkExpiration(),
+            new ProxyManagerSpec<>(
+                "CouchbaseCompareAndSwapBasedProxyManagerAsyncCollectionWithLongKeys",
+                () -> ThreadLocalRandom.current().nextLong(),
+                () -> Bucket4jCouchbase.compareAndSwapBasedBuilder(asyncCollection, Mapper.LONG)
+            ).checkExpiration()
+        );
+    }
+
+    @AfterAll
+    public static void cleanupCouchbase() {
+        if (cluster != null) {
+            cluster.disconnect();
+        }
+        if (couchbaseContainer != null) {
+            couchbaseContainer.stop();
+        }
+    }
+}

--- a/bucket4j-couchbase/src/test/resources/logback-test.xml
+++ b/bucket4j-couchbase/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+<configuration/>

--- a/bucket4j-parent/pom.xml
+++ b/bucket4j-parent/pom.xml
@@ -54,6 +54,7 @@
         <ehcache.version>3.8.1</ehcache.version>
 
         <testcontainers.version>1.20.1</testcontainers.version>
+        <jackson.annotations.version>2.20</jackson.annotations.version>
         <lettuce-version>5.0.2.RELEASE</lettuce-version>
         <jedis.version>4.4.6</jedis.version>
         <redisson.version>3.21.0</redisson.version>
@@ -64,6 +65,7 @@
         <mssql.version>12.4.2.jre8</mssql.version>
         <ojdbc.version>23.2.0.0</ojdbc.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <slf4j.version>2.0.9</slf4j.version>
         <bnd.version>7.1.0</bnd.version>
         <!-- default OSGi bundle symbolic name pattern -->
         <osgi.symbolicName>${project.groupId}.${modular-name}</osgi.symbolicName>
@@ -511,9 +513,21 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.3.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotations.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 <!--        <module>backward-compatibility-tests</module>-->
         <module>asciidoc</module>
         <module>bucket4j-mongodb</module>
+        <module>bucket4j-couchbase</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR updates the Couchbase integration.

  It keeps the existing Couchbase design based on KV operations, document CAS, and document expiry

  Included :
  - Couchbase integration updates
  - blocking and async usage support

  The underlying storage and concurrency model is unchanged:
  - raw binary document state
  - CAS-based updates
  - document expiry for `expirationAfterWrite(...)`

  Validation:
  - Couchbase tests pass locally
  - the Couchbase module passed in the full reactor
  - local performance checks were run after the changes