### PR TITLE
Support backoff in CAS retry strategy

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/AbstractProxyManagerBuilder.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/AbstractProxyManagerBuilder.java
@@ -203,6 +203,7 @@ public abstract class AbstractProxyManagerBuilder<K, P extends ProxyManager<K>, 
      * <ul>
      *     <li>Delegating decisions to a mediator component</li>
      *     <li>Applying arbitrary business logic (e.g., neural networks trained on traffic patterns)</li>
+     *     <li>Adding backoff, jitter or fixed delays between CAS retries</li>
      *     <li>Integrating metrics/monitoring for analysis and tuning</li>
      * </ul>
      *
@@ -210,7 +211,7 @@ public abstract class AbstractProxyManagerBuilder<K, P extends ProxyManager<K>, 
      * The retry strategy takes precedence over {@link #maxRetries(int)} if both are configured.
      *
      * <p>
-     * By default, retryStrategy is not set. This means that either maxRetries or infinite retries will be used.
+     * By default, retryStrategy is not set. This means that either maxRetries or infinite immediate retries will be used.
      *
      * @param retryStrategy the custom retry strategy for CAS operations.
      *

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/ClientSideConfig.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/ClientSideConfig.java
@@ -206,6 +206,7 @@ public class ClientSideConfig {
      * <ul>
      *     <li>Delegating decisions to a mediator component</li>
      *     <li>Applying arbitrary business logic (e.g., neural networks trained on traffic patterns)</li>
+     *     <li>Adding backoff, jitter or fixed delays between CAS retries</li>
      *     <li>Integrating metrics/monitoring for analysis and tuning</li>
      * </ul>
      *
@@ -213,7 +214,7 @@ public class ClientSideConfig {
      * The retry strategy takes precedence over {@link #withMaxRetries(int)} if both are configured.
      *
      * <p>
-     * By default, retryStrategy is not set. This means that either maxRetries or infinite retries will be used.
+     * By default, retryStrategy is not set. This means that either maxRetries or infinite immediate retries will be used.
      *
      * @param retryStrategy the custom retry strategy for CAS operations.
      *

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RetryDecision.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RetryDecision.java
@@ -1,0 +1,68 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Bucket4j
+ * %%
+ * Copyright (C) 2026 Ivan Vaskevych
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+package io.github.bucket4j.distributed.proxy;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Describes how the CAS executor should proceed after a failed compare-and-swap attempt.
+ */
+public final class RetryDecision {
+
+    private static final RetryDecision STOP = new RetryDecision(false, Duration.ZERO);
+    private static final RetryDecision RETRY_IMMEDIATELY = new RetryDecision(true, Duration.ZERO);
+
+    private final boolean retry;
+    private final Duration delay;
+
+    private RetryDecision(boolean retry, Duration delay) {
+        this.retry = retry;
+        this.delay = Objects.requireNonNull(delay);
+    }
+
+    public static RetryDecision stop() {
+        return STOP;
+    }
+
+    public static RetryDecision retryImmediately() {
+        return RETRY_IMMEDIATELY;
+    }
+
+    public static RetryDecision retryAfter(Duration delay) {
+        Objects.requireNonNull(delay);
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("Retry delay can not be negative: " + delay);
+        }
+        if (delay.isZero()) {
+            return RETRY_IMMEDIATELY;
+        }
+        return new RetryDecision(true, delay);
+    }
+
+    public boolean shouldRetry() {
+        return retry;
+    }
+
+    public Duration getDelay() {
+        return delay;
+    }
+}

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RetryStrategy.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RetryStrategy.java
@@ -20,6 +20,8 @@
 
 package io.github.bucket4j.distributed.proxy;
 
+import java.time.Duration;
+
 /**
  * A functional interface that allows custom retry logic for Compare-And-Swap (CAS) operations.
  *
@@ -37,16 +39,21 @@ package io.github.bucket4j.distributed.proxy;
  * Example usage:
  * <pre>{@code
  * // Simple retry limit
- * RetryStrategy limitedRetries = metadata -> metadata.getAttemptNumber() < 5;
+ * RetryStrategy limitedRetries = metadata ->
+ *     metadata.getAttemptNumber() < 5 ? RetryDecision.retryImmediately() : RetryDecision.stop();
  *
- * // Time-based retry
+ * // Time-based retry with exponential backoff
  * RetryStrategy timeBasedRetry = metadata ->
- *     metadata.getElapsedTimeNanos() < Duration.ofSeconds(1).toNanos();
+ *     metadata.getElapsedTimeNanos() < Duration.ofSeconds(1).toNanos()
+ *         ? RetryDecision.retryAfter(Duration.ofMillis(10L * metadata.getAttemptNumber()))
+ *         : RetryDecision.stop();
  *
  * // Bucket-specific retry logic with neural network
  * RetryStrategy bucketSpecific = metadata -> {
  *     String bucketKey = (String) metadata.getBucketKey();
- *     return evaluateNeuralModel(bucketKey, metadata.getAttemptNumber());
+ *     return evaluateNeuralModel(bucketKey, metadata.getAttemptNumber())
+ *         ? RetryDecision.retryImmediately()
+ *         : RetryDecision.stop();
  * };
  *
  * // Complex business logic
@@ -55,7 +62,9 @@ package io.github.bucket4j.distributed.proxy;
  *         metadata.getAttemptNumber(),
  *         metadata.getBucketKey(),
  *         metadata.getElapsedTimeNanos() / 1_000_000);
- *     return myMediatorComponent.shouldRetry(metadata);
+ *     return myMediatorComponent.shouldRetry(metadata)
+ *         ? RetryDecision.retryAfter(Duration.ofMillis(50))
+ *         : RetryDecision.stop();
  * };
  * }</pre>
  *
@@ -65,12 +74,12 @@ package io.github.bucket4j.distributed.proxy;
 public interface RetryStrategy {
 
     /**
-     * Determines whether another CAS retry attempt should be made.
+     * Determines how CAS retries should proceed after a failed compare-and-swap attempt.
      *
      * @param metadata information about the current retry attempt
-     * @return {@code true} if another retry should be attempted, {@code false} to stop retrying
+     * @return a decision that describes whether the CAS loop should continue and how long to wait before retrying
      */
-    boolean shouldRetry(RetryMetadata metadata);
+    RetryDecision shouldRetry(RetryMetadata metadata);
 
     /**
      * Metadata about a CAS retry attempt.
@@ -151,4 +160,3 @@ public interface RetryStrategy {
         }
     }
 }
-

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/generic/compare_and_swap/AbstractCompareAndSwapBasedProxyManager.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/generic/compare_and_swap/AbstractCompareAndSwapBasedProxyManager.java
@@ -24,6 +24,7 @@ import io.github.bucket4j.BucketExceptions;
 import io.github.bucket4j.TimeMeter;
 import io.github.bucket4j.distributed.proxy.AbstractProxyManager;
 import io.github.bucket4j.distributed.proxy.ClientSideConfig;
+import io.github.bucket4j.distributed.proxy.RetryDecision;
 import io.github.bucket4j.distributed.proxy.RetryStrategy;
 import io.github.bucket4j.distributed.proxy.Timeout;
 import io.github.bucket4j.distributed.remote.CommandResult;
@@ -33,6 +34,9 @@ import io.github.bucket4j.distributed.remote.Request;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Supplier;
 
 /**
  * The base class for proxy managers that built on top of idea that underlining storage provide transactions and locking.
@@ -57,7 +61,7 @@ public abstract class AbstractCompareAndSwapBasedProxyManager<K> extends Abstrac
 
         long startTimeNanos = System.nanoTime();
         int attempt = 0;
-        int maxAttempts = maxRetries.orElse(Integer.MAX_VALUE);
+        int maxAttempts = retryStrategy.isPresent() ? Integer.MAX_VALUE : maxRetries.orElse(Integer.MAX_VALUE);
 
         while (attempt < maxAttempts) {
             CommandResult<T> result = execute(request, operation, timeout);
@@ -71,9 +75,11 @@ public abstract class AbstractCompareAndSwapBasedProxyManager<K> extends Abstrac
                 RetryStrategy.RetryMetadata metadata = new RetryStrategy.RetryMetadata(
                     attempt + 1, key, startTimeNanos, currentTimeNanos
                 );
-                if (!retryStrategy.get().shouldRetry(metadata)) {
+                RetryDecision retryDecision = retryStrategy.get().shouldRetry(metadata);
+                if (!retryDecision.shouldRetry()) {
                     throw BucketExceptions.maxRetriesExceeded(attempt + 1);
                 }
+                sleepBeforeRetry(timeout, retryDecision);
             }
 
             attempt++;
@@ -125,11 +131,14 @@ public abstract class AbstractCompareAndSwapBasedProxyManager<K> extends Abstrac
             RetryStrategy.RetryMetadata metadata = new RetryStrategy.RetryMetadata(
                 attemptCount, key, startTimeNanos, currentTimeNanos
             );
-            if (!retryStrategy.get().shouldRetry(metadata)) {
+            RetryDecision retryDecision = retryStrategy.get().shouldRetry(metadata);
+            if (!retryDecision.shouldRetry()) {
                 CompletableFuture<CommandResult<T>> failed = new CompletableFuture<>();
                 failed.completeExceptionally(BucketExceptions.maxRetriesExceeded(attemptCount));
                 return failed;
             }
+            return delayRetry(timeout, retryDecision, () -> executeAsync(request, operation, timeout)
+                .thenCompose((CommandResult<T> response) -> retryIfCasWasUnsuccessful(operation, request, response, timeout, attemptCount + 1, key, startTimeNanos)));
         } else {
             // Fall back to max retries check
             Optional<Integer> maxRetries = getClientSideConfig().getMaxRetries();
@@ -165,6 +174,36 @@ public abstract class AbstractCompareAndSwapBasedProxyManager<K> extends Abstrac
             return clientSideConfig;
         }
         return clientSideConfig.withClientClock(TimeMeter.SYSTEM_MILLISECONDS);
+    }
+
+    private void sleepBeforeRetry(Timeout timeout, RetryDecision retryDecision) {
+        long delayNanos = retryDecision.getDelay().toNanos();
+        if (delayNanos == 0) {
+            return;
+        }
+
+        timeout.run(requestTimeout -> {
+            long boundedDelay = requestTimeout.map(remainingTimeout -> Math.min(delayNanos, remainingTimeout)).orElse(delayNanos);
+            if (boundedDelay > 0) {
+                LockSupport.parkNanos(boundedDelay);
+            }
+        });
+    }
+
+    private <T> CompletableFuture<T> delayRetry(Timeout timeout, RetryDecision retryDecision, Supplier<CompletableFuture<T>> retrySupplier) {
+        long delayNanos = retryDecision.getDelay().toNanos();
+        if (delayNanos == 0) {
+            return retrySupplier.get();
+        }
+
+        return timeout.callAsync(requestTimeout -> {
+            long boundedDelay = requestTimeout.map(remainingTimeout -> Math.min(delayNanos, remainingTimeout)).orElse(delayNanos);
+            if (boundedDelay == 0) {
+                return retrySupplier.get();
+            }
+            return CompletableFuture.runAsync(() -> { }, CompletableFuture.delayedExecutor(boundedDelay, TimeUnit.NANOSECONDS))
+                .thenCompose(ignored -> retrySupplier.get());
+        });
     }
 
 }

--- a/bucket4j-core/src/test/java/io/github/bucket4j/distributed/proxy/AbstractProxyManagerBuilderTest.java
+++ b/bucket4j-core/src/test/java/io/github/bucket4j/distributed/proxy/AbstractProxyManagerBuilderTest.java
@@ -37,7 +37,7 @@ public class AbstractProxyManagerBuilderTest {
         TestProxyManagerBuilder builder = new TestProxyManagerBuilder();
         
         // Configure retryStrategy
-        RetryStrategy strategy = metadata -> metadata.getAttemptNumber() < 10;
+        RetryStrategy strategy = metadata -> metadata.getAttemptNumber() < 10 ? RetryDecision.retryImmediately() : RetryDecision.stop();
         builder.retryStrategy(strategy);
         
         // Verify it's set in the builder
@@ -94,7 +94,7 @@ public class AbstractProxyManagerBuilderTest {
         TestProxyManagerBuilder builder = new TestProxyManagerBuilder();
         
         // Configure both
-        RetryStrategy strategy = metadata -> metadata.getAttemptNumber() < 10;
+        RetryStrategy strategy = metadata -> metadata.getAttemptNumber() < 10 ? RetryDecision.retryImmediately() : RetryDecision.stop();
         builder.maxRetries(5).retryStrategy(strategy);
         
         // Verify both are set
@@ -154,4 +154,3 @@ public class AbstractProxyManagerBuilderTest {
         }
     }
 }
-

--- a/bucket4j-core/src/test/java/io/github/bucket4j/distributed/proxy/MaxRetriesTest.java
+++ b/bucket4j-core/src/test/java/io/github/bucket4j/distributed/proxy/MaxRetriesTest.java
@@ -116,6 +116,117 @@ public class MaxRetriesTest {
         assertEquals(5, attemptCount.get());
     }
 
+    @Test
+    public void testRetryStrategyTakesPrecedenceOverMaxRetriesForSync() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        ClientSideConfig config = ClientSideConfig.getDefault()
+            .withMaxRetries(1)
+            .withRetryStrategy(metadata ->
+                metadata.getAttemptNumber() < 3 ? RetryDecision.retryImmediately() : RetryDecision.stop()
+            );
+
+        FailingCasProxyManager<String> proxyManager = new FailingCasProxyManager<>(config, attemptCount);
+
+        BucketConfiguration bucketConfig = BucketConfiguration.builder()
+            .addLimit(Bandwidth.simple(10, Duration.ofSeconds(1)))
+            .build();
+
+        BucketProxy bucket = proxyManager.builder().build("test-key", bucketConfig);
+
+        BucketExecutionException exception = assertThrows(BucketExecutionException.class, () -> bucket.tryConsume(1));
+        assertTrue(exception.getMessage().contains("CAS operation failed after 3 retry attempts"));
+        assertEquals(3, attemptCount.get());
+    }
+
+    @Test
+    public void testSyncRetryStrategyCanDelayRetries() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        ClientSideConfig config = ClientSideConfig.getDefault().withRetryStrategy(metadata ->
+            metadata.getAttemptNumber() < 3 ? RetryDecision.retryAfter(Duration.ofMillis(25)) : RetryDecision.stop()
+        );
+
+        FailingCasProxyManager<String> proxyManager = new FailingCasProxyManager<>(config, attemptCount);
+
+        BucketConfiguration bucketConfig = BucketConfiguration.builder()
+            .addLimit(Bandwidth.simple(10, Duration.ofSeconds(1)))
+            .build();
+
+        BucketProxy bucket = proxyManager.builder().build("test-key", bucketConfig);
+
+        long startNanos = System.nanoTime();
+        BucketExecutionException exception = assertThrows(BucketExecutionException.class, () -> bucket.tryConsume(1));
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
+
+        assertTrue(exception.getMessage().contains("CAS operation failed after 3 retry attempts"));
+        assertEquals(3, attemptCount.get());
+        assertTrue(elapsedMillis >= 40, "Expected sync retry delay to be visible, but took only " + elapsedMillis + "ms");
+    }
+
+    @Test
+    public void testAsyncRetryStrategyCanDelayRetries() throws Exception {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        ClientSideConfig config = ClientSideConfig.getDefault().withRetryStrategy(metadata ->
+            metadata.getAttemptNumber() < 3 ? RetryDecision.retryAfter(Duration.ofMillis(25)) : RetryDecision.stop()
+        );
+
+        FailingCasProxyManager<String> proxyManager = new FailingCasProxyManager<>(config, attemptCount);
+
+        BucketConfiguration bucketConfig = BucketConfiguration.builder()
+            .addLimit(Bandwidth.simple(10, Duration.ofSeconds(1)))
+            .build();
+
+        var asyncBucket = proxyManager.asAsync().builder().build("test-key", bucketConfig);
+
+        long startNanos = System.nanoTime();
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> asyncBucket.tryConsume(1).get());
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
+
+        assertTrue(exception.getCause() instanceof BucketExecutionException);
+        assertTrue(exception.getCause().getMessage().contains("CAS operation failed after 3 retry attempts"));
+        assertEquals(3, attemptCount.get());
+        assertTrue(elapsedMillis >= 40, "Expected async retry delay to be visible, but took only " + elapsedMillis + "ms");
+    }
+
+    @Test
+    public void testSyncRetryStrategyStopsOnTimeoutBeforeDelayedRetry() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        ClientSideConfig config = ClientSideConfig.getDefault()
+            .withRequestTimeout(Duration.ofMillis(20))
+            .withRetryStrategy(metadata -> RetryDecision.retryAfter(Duration.ofMillis(100)));
+
+        FailingCasProxyManager<String> proxyManager = new FailingCasProxyManager<>(config, attemptCount);
+
+        BucketConfiguration bucketConfig = BucketConfiguration.builder()
+            .addLimit(Bandwidth.simple(10, Duration.ofSeconds(1)))
+            .build();
+
+        BucketProxy bucket = proxyManager.builder().build("test-key", bucketConfig);
+
+        BucketExecutionException exception = assertThrows(BucketExecutionException.class, () -> bucket.tryConsume(1));
+        assertTrue(exception instanceof io.github.bucket4j.TimeoutException);
+        assertEquals(1, attemptCount.get());
+    }
+
+    @Test
+    public void testAsyncRetryStrategyStopsOnTimeoutBeforeDelayedRetry() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        ClientSideConfig config = ClientSideConfig.getDefault()
+            .withRequestTimeout(Duration.ofMillis(20))
+            .withRetryStrategy(metadata -> RetryDecision.retryAfter(Duration.ofMillis(100)));
+
+        FailingCasProxyManager<String> proxyManager = new FailingCasProxyManager<>(config, attemptCount);
+
+        BucketConfiguration bucketConfig = BucketConfiguration.builder()
+            .addLimit(Bandwidth.simple(10, Duration.ofSeconds(1)))
+            .build();
+
+        var asyncBucket = proxyManager.asAsync().builder().build("test-key", bucketConfig);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> asyncBucket.tryConsume(1).get());
+        assertTrue(exception.getCause() instanceof io.github.bucket4j.TimeoutException);
+        assertEquals(1, attemptCount.get());
+    }
+
     /**
      * Mock proxy manager that always fails CAS operations
      */
@@ -246,4 +357,3 @@ public class MaxRetriesTest {
         }
     }
 }
-

--- a/bucket4j-redis/bucket4j-lettuce/src/test/java/io/github/bucket4j/redis/LettuceBasedProxyManagerStandaloneTest.java
+++ b/bucket4j-redis/bucket4j-lettuce/src/test/java/io/github/bucket4j/redis/LettuceBasedProxyManagerStandaloneTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
 
+import io.github.bucket4j.distributed.proxy.RetryDecision;
 import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
-import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
 import io.github.bucket4j.tck.AbstractDistributedBucketTest;
 import io.github.bucket4j.tck.ProxyManagerSpec;
 import io.lettuce.core.RedisClient;
@@ -43,6 +43,12 @@ public class LettuceBasedProxyManagerStandaloneTest extends AbstractDistributedB
                 "LettuceBasedProxyManager_StringKey",
                 () -> UUID.randomUUID().toString(),
                 () -> Bucket4jLettuce.casBasedBuilder(redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE)))
+            ).checkExpiration(),
+            new ProxyManagerSpec<>(
+                "LettuceBasedProxyManager_StringKey_WithBackoffRetryStrategy",
+                () -> UUID.randomUUID().toString(),
+                () -> Bucket4jLettuce.casBasedBuilder(redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE)))
+                    .retryStrategy(metadata -> RetryDecision.retryAfter(Duration.ofNanos(metadata.getAttemptNumber())))
             ).checkExpiration()
         );
     }


### PR DESCRIPTION
CAS-based proxy managers retried immediately after compare-and-swap conflicts. That created a tight retry loop under contention: no backoff, no jitter, and no way for clients to pace retries. In practice this could amplify load on the backend, increase contention, and waste CPU while still failing with the same CAS conflict repeatedly.

Replace the boolean-only RetryStrategy contract with a RetryDecision that can either stop, retry immediately, or retry after a delay. Wire the shared CAS executor to honor that decision in both sync and async paths, while keeping the default behavior unchanged for users who do not configure a retry strategy. The sync path now parks between retries, the async path schedules delayed retries without blocking, and both paths respect request timeouts.

Default behavior is unchanged:
- no configured RetryStrategy: retries are still immediate
- maxRetries without RetryStrategy: still immediate retries, just capped
- only when a custom RetryStrategy returns RetryDecision.retryAfter(...) do we add delay

So the change adds an opt-in backoff mechanism.