### PR TITLE
docs: clarify Redis module dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,31 +81,31 @@ In addition to local in-memory buckets, the Bucket4j supports clustered usage sc
 | Back-end                   |  Async supported | Redis cluster supported |                                       Documentation link                                       |
 | :---                       | :---:            |:-----------------------:|:----------------------------------------------------------------------------------------------:|
 | ```Redis/Vert.x Redis Client``` |  Yes             |           Yes           | [bucket4j-redis/Vert.x](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-vertx)         |
-| ```Redis/Redisson```       |  Yes             |           Yes           |    [bucket4j-redis/Redisson](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-redisson)     |
-| ```Redis/Jedis```          |  No              |           Yes           |  [bucket4j-redis/Jedis](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-jedis)             |
-| ```Redis/Lettuce```        |  Yes             |           Yes           | [bucket4j-redis/Lettuce](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-lettuce)          |
+| ```Redis/Redisson```       |  Yes             |           Yes           |    [bucket4j-redis/Redisson](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-redisson)     |
+| ```Redis/Jedis```          |  No              |           Yes           |  [bucket4j-redis/Jedis](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-jedis)             |
+| ```Redis/Lettuce```        |  Yes             |           Yes           | [bucket4j-redis/Lettuce](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-lettuce)          |
 
 ### Valkey back-ends
 | Back-end                   |  Async supported | Redis cluster supported |                                       Documentation link                                       |
 | :---                       | :---:            |:-----------------------:|:----------------------------------------------------------------------------------------------:|
-| ```Valkey/Glide```         |  Yes             |           Yes           | [bucket4j-valkey/Glide](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-glide)             |
+| ```Valkey/Glide```         |  Yes             |           Yes           | [bucket4j-valkey/Glide](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-glide)             |
 
 
 ### Mongo back-ends
 | Back-end                      | Async supported |                                          Documentation link                                          |
 |:------------------------------|:---------------:|:----------------------------------------------------------------------------------------------------:|
-| ```Mongodb/mongodb-driver-sync```            |       No        | [bucket4j-mongodb/sync](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-mongodb-sync)   |
-| ```Mongodb/mongodb-driver-reactivestreams``` |       Yes       | [bucket4j-mongodb/async](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-mongodb-async) |
+| ```Mongodb/mongodb-driver-sync```            |       No        | [bucket4j-mongodb/sync](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-mongodb-sync)   |
+| ```Mongodb/mongodb-driver-reactivestreams``` |       Yes       | [bucket4j-mongodb/async](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-mongodb-async) |
 
 ### JDBC back-ends
 | Back-end                   |                                  Documentation link                                   |
 |:---------------------------|:-------------------------------------------------------------------------------------:|
-| ```MySQL```                |      [bucket4j-mysql](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-mysql)      |
-| ```PostgreSQL```           | [bucket4j-postgresql](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-postgresql) |
-| ```Oracle```               |     [bucket4j-oracle](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-oracle)     |
-| ```Microsoft SQL Server``` |      [bucket4j-mssql](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-mssql)      |
-| ```MariaDB```              |    [bucket4j-mariadb](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-mariadb)    |
-| ```DB2```                  |        [bucket4j-db2](https://bucket4j.github.io/8.16.1/toc.html#bucket4j-db2)        |
+| ```MySQL```                |      [bucket4j-mysql](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-mysql)      |
+| ```PostgreSQL```           | [bucket4j-postgresql](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-postgresql) |
+| ```Oracle```               |     [bucket4j-oracle](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-oracle)     |
+| ```Microsoft SQL Server``` |      [bucket4j-mssql](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-mssql)      |
+| ```MariaDB```              |    [bucket4j-mariadb](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-mariadb)    |
+| ```DB2```                  |        [bucket4j-db2](https://bucket4j.github.io/8.18.0/toc.html#bucket4j-db2)        |
 
 
 ### Local caches support

--- a/asciidoc/src/main/docs/asciidoc/distributed/redis/lettuce.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/redis/lettuce.adoc
@@ -1,7 +1,7 @@
 [[bucket4j-lettuce, Bucket4j-Lettuce]]
 ==== Lettuce integration
 ===== Dependencies
-To use ``bucket4j-letucce`` extension you need to add following dependency:
+To use ``bucket4j-lettuce`` extension you need to add following dependency:
 [source, xml, subs=attributes+]
 ----
 <dependency>

--- a/asciidoc/src/main/docs/asciidoc/distributed/redis/redis.adoc
+++ b/asciidoc/src/main/docs/asciidoc/distributed/redis/redis.adoc
@@ -28,6 +28,8 @@ Bucket4j provides integration with five Redis libraries:
 |===
 IMPORTANT: For all libraries mentioned above concurrent access to Redis is solved by Compare&Swap pattern, this can be improved in the future via switching to Javascript stored procedures.
 
+NOTE: The ``bucket4j_jdk17-redis`` artifact is an aggregator module and should not be used as an application dependency. Use ``bucket4j_jdk17-redis-common`` together with a concrete Redis client module, such as ``bucket4j_jdk17-lettuce``, ``bucket4j_jdk17-redisson``, ``bucket4j_jdk17-jedis``, ``bucket4j_jdk17-vertx``, or ``bucket4j_jdk17-glide``.
+
 include::lettuce.adoc[]
 
 include::redisson.adoc[]


### PR DESCRIPTION
## Summary

This PR clarifies Redis module dependency usage in the documentation.

The Redis integration has an aggregator module, `bucket4j_jdk17-redis`, but applications should depend on `bucket4j_jdk17-redis-common` together with a concrete Redis client
module such as `bucket4j_jdk17-lettuce`, `bucket4j_jdk17-redisson`, `bucket4j_jdk17-jedis`, `bucket4j_jdk17-vertx`, or `bucket4j_jdk17-glide`.

This clarification should help avoid confusion about which Redis artifacts are intended to be used as application dependencies.

## Changes

- Added a note to the Redis documentation explaining that `bucket4j_jdk17-redis` is an aggregator module
- Fixed a typo in the Lettuce integration section: `bucket4j-letucce` -> `bucket4j-lettuce`
- Updated stale documentation links in `README.md` from `8.16.1` to `8.18.0`

## Related Issue

Related to #581

## Verification

- `./mvnw -pl asciidoc test`
- `git diff --check`